### PR TITLE
Added error 123 to skip list

### DIFF
--- a/CCopyAction.h
+++ b/CCopyAction.h
@@ -105,7 +105,7 @@ public:
             {
                 DWORD error = ::GetLastError();
 
-                if ((error == 5 || error == 32) && _skipDenied)
+                if ((error == 5 || error == 32 || error == 123) && _skipDenied)
                 {
                     CString message; 
                     message.Format(TEXT("Error %d accessing file %s. Skipping."), error, sourceFile); 


### PR DESCRIPTION
I needed this to automatically skip files with very long filenames while coping from Windows Server 2008 to Linux Samba share (255 symbols length restriction).
