### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/COptions.h
+++ b/COptions.h
@@ -305,7 +305,7 @@ private:
             }
             else if (result > MAX_PATH)
             {
-                delete normalizedPath; 
+                delete [] normalizedPath; 
                 length = result; 
             }
             else

--- a/Console.h
+++ b/Console.h
@@ -89,7 +89,7 @@ public:
         DWORD charsWritten; 
         BOOL bWorked = ::WriteFile(get_StandardOutput(), narrowMessage, messageString.GetLength(), &charsWritten, NULL); 
 
-        Utilities::Free(narrowMessage); 
+        delete [] narrowMessage; 
 
         if (!bWorked)
         {


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V611](https://www.viva64.com/en/w/v611/) The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Consider inspecting this code. It's probably better to use 'delete [] narrowMessage;'. Check lines: 'utilities.h:295', 'console.h:92'. console.h 92
[V611](https://www.viva64.com/en/w/v611/) The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Consider inspecting this code. It's probably better to use 'delete [] normalizedPath;'. coptions.h 308